### PR TITLE
set path in MATLAB wrapper so that you can call it from any folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 
-This software package contains a Barnes-Hut implementation of the t-SNE algorithm. The implementation is described in [this paper](http://lvdmaaten.github.io/publications/papers/JMLR_2014.pdf).
+This software package contains a Barnes-Hut implementation of the t-SNE algorithm. The implementation is described in [this paper](http://lvdmaaten.github.io/publications/papers/JMLR_2014.pdf). This was originally written by [lvdmaaten](https://github.com/lvdmaaten/bhtsne). 
 
 
-# Installation #
+# Installation 
 
 On Linux or OS X, compile the source using the following command:
 
@@ -34,7 +34,7 @@ On Windows using Visual C++, do the following in your command line:
 
 The executable will be called `windows\bh_tsne.exe`.
 
-# Usage #
+# Usage 
 
 The code comes with wrappers for Matlab and Python. These wrappers write your data to a file called `data.dat`, run the `bh_tsne` binary, and read the result file `result.dat` that the binary produces. There are also external wrappers available for [Torch](https://github.com/clementfarabet/manifold) and [R](https://github.com/jkrijthe/Rtsne). Writing your own wrapper should be straightforward; please refer to one of the existing wrappers for the format of the data and result files.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
+# Barnes-Hut t-distributed Stochastic Neighbourhood Embedding 
 
 This software package contains a Barnes-Hut implementation of the t-SNE algorithm. The implementation is described in [this paper](http://lvdmaaten.github.io/publications/papers/JMLR_2014.pdf). This was originally written by [lvdmaaten](https://github.com/lvdmaaten/bhtsne). 
 
 
 # Installation 
 
+The recommended way to install this package is to use my package manager:
+
+```matlab
+% paste this into your MATLAB prompt
+urlwrite('http://srinivas.gs/install.m','install.m'); 
+install bhtsne
+install srinivas.gs_mtools
+```
+
 On Linux or OS X, compile the source using the following command:
 
-```
+```bash
 g++ sptree.cpp tsne.cpp -o bh_tsne -O2
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,12 @@
-# Barnes-Hut t-distributed Stochastic Neighbourhood Embedding 
 
-This software package contains a Barnes-Hut implementation of the t-SNE algorithm. The implementation is described in [this paper](http://lvdmaaten.github.io/publications/papers/JMLR_2014.pdf). This was originally written by [lvdmaaten](https://github.com/lvdmaaten/bhtsne). 
+This software package contains a Barnes-Hut implementation of the t-SNE algorithm. The implementation is described in [this paper](http://lvdmaaten.github.io/publications/papers/JMLR_2014.pdf).
 
 
-# Installation 
-
-The recommended way to install this package is to use my package manager:
-
-```matlab
-% paste this into your MATLAB prompt
-urlwrite('http://srinivas.gs/install.m','install.m'); 
-install bhtsne
-install srinivas.gs_mtools
-```
+# Installation #
 
 On Linux or OS X, compile the source using the following command:
 
-```bash
+```
 g++ sptree.cpp tsne.cpp -o bh_tsne -O2
 ```
 
@@ -44,7 +34,7 @@ On Windows using Visual C++, do the following in your command line:
 
 The executable will be called `windows\bh_tsne.exe`.
 
-# Usage 
+# Usage #
 
 The code comes with wrappers for Matlab and Python. These wrappers write your data to a file called `data.dat`, run the `bh_tsne` binary, and read the result file `result.dat` that the binary produces. There are also external wrappers available for [Torch](https://github.com/clementfarabet/manifold) and [R](https://github.com/jkrijthe/Rtsne). Writing your own wrapper should be straightforward; please refer to one of the existing wrappers for the format of the data and result files.
 

--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -46,6 +46,14 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
 % CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
 % IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
 % OF SUCH DAMAGE.
+% 
+%
+% 
+% 
+% modified by Srinivas Gorur-Shandilya at 9:18 , 11 September 2015. Contact me at http://srinivas.gs/contact/ 
+% with the following changes:
+% this function now is internally cached using cache.m to speed up subsequent runs. 
+
 
 
     if ~exist('no_dims', 'var') || isempty(no_dims)
@@ -59,6 +67,21 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
     end
     if ~exist('theta', 'var') || isempty(theta)
         theta = 0.5;
+    end
+
+    temp = struct;
+    temp.X = X;
+    temp.no_dims = no_dims;
+    temp.initial_dims = initial_dims;
+    temp.perplexity = perplexity;
+    temp.theta = theta;
+    hash = dataHash(temp);
+    disp(hash)
+    mappedX = cache(hash);
+    if ~isempty(mappedX)
+        disp('using cached data...')
+        return
+    else
     end
     
     % Perform the initial dimensionality reduction using PCA
@@ -81,6 +104,9 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
     landmarks = landmarks + 1;              % correct for Matlab indexing
     delete('data.dat');
     delete('result.dat');
+
+    % write to cache
+    cache(hash,mappedX);
 end
 
 

--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -46,13 +46,6 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
 % CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
 % IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
 % OF SUCH DAMAGE.
-% 
-%
-% 
-% 
-% modified by Srinivas Gorur-Shandilya at 9:18 , 11 September 2015. Contact me at http://srinivas.gs/contact/ 
-% with the following changes:
-% this function now is internally cached using cache.m to speed up subsequent runs. 
 
     % rotate the input so that it makes sense
     if size(X,1) < size(X,2)
@@ -79,21 +72,6 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
         theta = 0.5;
     end
 
-    temp = struct;
-    temp.X = X;
-    temp.no_dims = no_dims;
-    temp.initial_dims = initial_dims;
-    temp.perplexity = perplexity;
-    temp.theta = theta;
-    hash = dataHash(temp);
-    disp(hash)
-    mappedX = cache(hash);
-    if ~isempty(mappedX)
-        disp('using cached data...')
-        return
-    else
-    end
-    
     % Perform the initial dimensionality reduction using PCA
     X = double(X);
     X = bsxfun(@minus, X, mean(X, 1));
@@ -115,8 +93,6 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
     delete('data.dat');
     delete('result.dat');
 
-    % write to cache
-    cache(hash,mappedX);
 end
 
 

--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -76,7 +76,7 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
     
     % Run the fast diffusion SNE implementation
     write_data(X, no_dims, theta, perplexity);
-    tic, system('./bh_tsne'); toc
+    tic, system('bh_tsne'); toc
     [mappedX, landmarks, costs] = read_data;   
     landmarks = landmarks + 1;              % correct for Matlab indexing
     delete('data.dat');

--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -47,11 +47,6 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
 % IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
 % OF SUCH DAMAGE.
 
-    % rotate the input so that it makes sense
-    if size(X,1) < size(X,2)
-        X = X';
-    end
-
     % modify environment to get paths for non-matlab code right
     path1 = getenv('PATH');
     if isempty(strfind(path1,[':' fileparts(which('fast_tsne'))]))

--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -54,6 +54,10 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
 % with the following changes:
 % this function now is internally cached using cache.m to speed up subsequent runs. 
 
+    % rotate the input so that it makes sense
+    if size(X,1) < size(X,2)
+        X = X';
+    end
 
     % modify environment to get paths for non-matlab code right
     path1 = getenv('PATH');

--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -55,6 +55,12 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta)
 % this function now is internally cached using cache.m to speed up subsequent runs. 
 
 
+    % modify environment to get paths for non-matlab code right
+    path1 = getenv('PATH');
+    if isempty(strfind(path1,[':' fileparts(which('fast_tsne'))]))
+        path1 = [path1 ':' fileparts(which('fast_tsne'))];
+    end
+    setenv('PATH', path1);
 
     if ~exist('no_dims', 'var') || isempty(no_dims)
         no_dims = 2;


### PR DESCRIPTION
I updated the wrapper so that it adds to path the folder that contains the binary. this way, you can run `fast_tsne` from any path, not just the one that contains the binary. 