### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Demonstration of usage in Matlab:
 ```matlab
 filename = websave('mnist_train.mat', 'https://github.com/awni/cs224n-pa4/blob/master/Simple_tSNE/mnist_train.mat?raw=true');
 load(filename);
-numDims = 2; pcaDims = 50; perplexity = 50; theta = .5; alg = 'eig';
+numDims = 2; pcaDims = 50; perplexity = 50; theta = .5; alg = 'svd';
 map = fast_tsne(digits', numDims, pcaDims, perplexity, theta, alg);
 gscatter(map(:,1), map(:,2), labels');
 ```


### PR DESCRIPTION
example didn't work with `alg = 'eig' ` because covX has negative eigenvalues (throws error in `pca`). Switched to `'svd'`.