### PR TITLE
normalise by using the maximum (absolute) value 

### DIFF
--- a/tsne.cpp
+++ b/tsne.cpp
@@ -85,7 +85,7 @@ void TSNE::run(double* X, int N, int D, double* Y, int no_dims, double perplexit
     zeroMean(X, N, D);
     double max_X = .0;
     for(int i = 0; i < N * D; i++) {
-        if(X[i] > max_X) max_X = X[i];
+        if(fabs(X[i]) > max_X) max_X = fabs(X[i]);
     }
     for(int i = 0; i < N * D; i++) X[i] /= max_X;
 


### PR DESCRIPTION
I think the normalisation should use the maximum absolute value and not the maximum positive value.

Anyway, is there a reason why you are not using std instead of max? 