### PR TITLE
Max_iter and no_pca options + improved memory performance for python wrapper

### DIFF
--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -1,4 +1,4 @@
-function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta, alg)
+function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta, alg, max_iter)
 %FAST_TSNE Runs the C++ implementation of Barnes-Hut t-SNE
 %
 %   mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta, alg)
@@ -65,6 +65,9 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta, alg)
     if ~exist('alg', 'var') || isempty(alg)
         alg = 'svd';
     end
+    if ~exist('max_iter', 'var') || isempty(max_iter)
+       max_iter=1000; 
+    end
     
     % Perform the initial dimensionality reduction using PCA
     X = double(X);
@@ -75,7 +78,7 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta, alg)
     % Run the fast diffusion SNE implementation
     tsne_path = which('fast_tsne');
     tsne_path = fileparts(tsne_path);
-    write_data(X, no_dims, theta, perplexity);
+    write_data(X, no_dims, theta, perplexity, max_iter);
     tic, system(fullfile(tsne_path,'./bh_tsne')); toc
     [mappedX, landmarks, costs] = read_data;   
     landmarks = landmarks + 1;              % correct for Matlab indexing
@@ -85,7 +88,7 @@ end
 
 
 % Writes the datafile for the fast t-SNE implementation
-function write_data(X, no_dims, theta, perplexity)
+function write_data(X, no_dims, theta, perplexity, max_iter)
     [n, d] = size(X);
     h = fopen('data.dat', 'wb');
 	fwrite(h, n, 'integer*4');
@@ -93,6 +96,7 @@ function write_data(X, no_dims, theta, perplexity)
     fwrite(h, theta, 'double');
     fwrite(h, perplexity, 'double');
 	fwrite(h, no_dims, 'integer*4');
+    fwrite(h, max_iter, 'integer*4');
     fwrite(h, X', 'double');
 	fclose(h);
 end

--- a/tsne.cpp
+++ b/tsne.cpp
@@ -676,8 +676,8 @@ bool TSNE::load_data(double** data, int* n, int* d, int* no_dims, double* theta,
 	fread(d, sizeof(int), 1, h);											// original dimensionality
     fread(theta, sizeof(double), 1, h);										// gradient accuracy
 	fread(perplexity, sizeof(double), 1, h);								// perplexity
-	fread(no_dims, sizeof(int), 1, h);
-    fread(max_iter, sizeof(int),1,h);                                      // output dimensionality
+	fread(no_dims, sizeof(int), 1, h);                                      // output dimensionality
+    fread(max_iter, sizeof(int),1,h);                                       // maximum number of iterations
 	*data = (double*) malloc(*d * *n * sizeof(double));
     if(*data == NULL) { printf("Memory allocation failed!\n"); exit(1); }
     fread(*data, sizeof(double), *n * *d, h);                               // the data

--- a/tsne.cpp
+++ b/tsne.cpp
@@ -664,7 +664,7 @@ double TSNE::randn() {
 
 // Function that loads data from a t-SNE file
 // Note: this function does a malloc that should be freed elsewhere
-bool TSNE::load_data(double** data, int* n, int* d, int* no_dims, double* theta, double* perplexity, int* rand_seed) {
+bool TSNE::load_data(double** data, int* n, int* d, int* no_dims, double* theta, double* perplexity, int* rand_seed, int* max_iter) {
 
 	// Open file, read first 2 integers, allocate memory, and read the data
     FILE *h;
@@ -676,7 +676,8 @@ bool TSNE::load_data(double** data, int* n, int* d, int* no_dims, double* theta,
 	fread(d, sizeof(int), 1, h);											// original dimensionality
     fread(theta, sizeof(double), 1, h);										// gradient accuracy
 	fread(perplexity, sizeof(double), 1, h);								// perplexity
-	fread(no_dims, sizeof(int), 1, h);                                      // output dimensionality
+	fread(no_dims, sizeof(int), 1, h);
+    fread(max_iter, sizeof(int),1,h);                                      // output dimensionality
 	*data = (double*) malloc(*d * *n * sizeof(double));
     if(*data == NULL) { printf("Memory allocation failed!\n"); exit(1); }
     fread(*data, sizeof(double), *n * *d, h);                               // the data
@@ -709,14 +710,14 @@ void TSNE::save_data(double* data, int* landmarks, double* costs, int n, int d) 
 int main() {
 
     // Define some variables
-	int origN, N, D, no_dims, *landmarks;
+	int origN, N, D, no_dims, max_iter, *landmarks;
 	double perc_landmarks;
 	double perplexity, theta, *data;
     int rand_seed = -1;
     TSNE* tsne = new TSNE();
 
     // Read the parameters and the dataset
-	if(tsne->load_data(&data, &origN, &D, &no_dims, &theta, &perplexity, &rand_seed)) {
+	if(tsne->load_data(&data, &origN, &D, &no_dims, &theta, &perplexity, &rand_seed, &max_iter)) {
 
 		// Make dummy landmarks
         N = origN;
@@ -728,7 +729,7 @@ int main() {
 		double* Y = (double*) malloc(N * no_dims * sizeof(double));
 		double* costs = (double*) calloc(N, sizeof(double));
         if(Y == NULL || costs == NULL) { printf("Memory allocation failed!\n"); exit(1); }
-		tsne->run(data, N, D, Y, no_dims, perplexity, theta, rand_seed, false);
+		tsne->run(data, N, D, Y, no_dims, perplexity, theta, rand_seed, false, max_iter);
 
 		// Save the results
 		tsne->save_data(Y, landmarks, costs, N, no_dims);

--- a/tsne.h
+++ b/tsne.h
@@ -43,7 +43,7 @@ class TSNE
 public:
     void run(double* X, int N, int D, double* Y, int no_dims, double perplexity, double theta, int rand_seed,
              bool skip_random_init, int max_iter=1000, int stop_lying_iter=250, int mom_switch_iter=250);
-    bool load_data(double** data, int* n, int* d, int* no_dims, double* theta, double* perplexity, int* rand_seed);
+    bool load_data(double** data, int* n, int* d, int* no_dims, double* theta, double* perplexity, int* rand_seed, int* max_iter);
     void save_data(double* data, int* landmarks, double* costs, int n, int d);
     void symmetrizeMatrix(unsigned int** row_P, unsigned int** col_P, double** val_P, int N); // should be static!
 


### PR DESCRIPTION
Added max_iter and no_pca options for bhtsne and python wrapper.

Image below show that the python wrapper is using even more memory than bh_tsne.
![Huge memory consumption](https://cloud.githubusercontent.com/assets/70431/17810641/0a277a48-6627-11e6-951f-2eccd47dd743.png)

Reduced memory consumption dramatically by rewriting the python wrapper.
Now data loading and pre-processing are executed in a forked process that releases the memory by calling sys.exit(0)
