### PR TITLE
Eliminated sqrt from VpTree distance calculation

### DIFF
--- a/tsne.cpp
+++ b/tsne.cpp
@@ -432,7 +432,7 @@ void TSNE::computeGaussianPerplexity(double* X, int N, int D, unsigned int** _ro
     for(int n = 0; n < N; n++) row_P[n + 1] = row_P[n] + (unsigned int) K;
 
     // Build ball tree on data set
-    VpTree<DataPoint, euclidean_distance>* tree = new VpTree<DataPoint, euclidean_distance>();
+    VpTree<DataPoint, squared_euclidean_distance>* tree = new VpTree<DataPoint, squared_euclidean_distance>();
     vector<DataPoint> obj_X(N, DataPoint(D, -1, X));
     for(int n = 0; n < N; n++) obj_X[n] = DataPoint(D, n, X + n * D);
     tree->create(obj_X);
@@ -462,13 +462,13 @@ void TSNE::computeGaussianPerplexity(double* X, int N, int D, unsigned int** _ro
         while(!found && iter < 200) {
 
             // Compute Gaussian kernel row
-            for(int m = 0; m < K; m++) cur_P[m] = exp(-beta * distances[m + 1] * distances[m + 1]);
+            for(int m = 0; m < K; m++) cur_P[m] = exp(-beta * distances[m + 1]);
 
             // Compute entropy of current row
             sum_P = DBL_MIN;
             for(int m = 0; m < K; m++) sum_P += cur_P[m];
             double H = .0;
-            for(int m = 0; m < K; m++) H += beta * (distances[m + 1] * distances[m + 1] * cur_P[m]);
+            for(int m = 0; m < K; m++) H += beta * (distances[m + 1] * cur_P[m]);
             H = (H / sum_P) + log(sum_P);
 
             // Evaluate whether the entropy is within the tolerance level

--- a/vptree.h
+++ b/vptree.h
@@ -87,7 +87,7 @@ public:
     double x(int d) const { return _x[d]; }
 };
 
-double euclidean_distance(const DataPoint &t1, const DataPoint &t2) {
+double squared_euclidean_distance(const DataPoint &t1, const DataPoint &t2) {
     double dd = .0;
     double* x1 = t1._x;
     double* x2 = t2._x;
@@ -96,7 +96,7 @@ double euclidean_distance(const DataPoint &t1, const DataPoint &t2) {
         diff = (x1[d] - x2[d]);
         dd += diff * diff;
     }
-    return sqrt(dd);
+    return dd;
 }
 
 


### PR DESCRIPTION
Optimized ball tree building phase to perform in 20% - 30% of original cpu time by eliminating sqrt from distance calculation.