### PR TITLE
Added error handling in Matlab and automatic compilation on unix systems

### DIFF
--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -79,7 +79,12 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta, alg, m
     tsne_path = which('fast_tsne');
     tsne_path = fileparts(tsne_path);
     write_data(X, no_dims, theta, perplexity, max_iter);
-    tic, system(fullfile(tsne_path,'./bh_tsne')); toc
+    tic
+    [flag, cmdout] = system(fullfile(tsne_path,'./bh_tsne'));
+    if(flag~=0)
+        error(cmdout);
+    end
+    toc
     [mappedX, landmarks, costs] = read_data;   
     landmarks = landmarks + 1;              % correct for Matlab indexing
     delete('data.dat');

--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -75,9 +75,18 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta, alg, m
     M = pca(X,'NumComponents',initial_dims,'Algorithm',alg);
     X = X * M;
     
-    % Run the fast diffusion SNE implementation
     tsne_path = which('fast_tsne');
     tsne_path = fileparts(tsne_path);
+    
+    % Compile t-SNE C code
+    if(~exist(fullfile(tsne_path,'./bh_tsne','file') && isunix)
+        system(sprintf('g++ %s %s -o %s -O2',...
+            fullfile(tsne_path,'./sptree.cpp'),...
+            fullfile(tsne_path,'./tsne.cpp',...
+            fullfile(tsne_path,'./bh_tsne')));
+    end
+
+    % Run the fast diffusion SNE implementation
     write_data(X, no_dims, theta, perplexity, max_iter);
     tic
     [flag, cmdout] = system(fullfile(tsne_path,'./bh_tsne'));


### PR DESCRIPTION
When `bh_tsne` exits with an error (e.g. too high perplexity for amount of data) this error is not shown in Matlab. Therefore, error checking needed to be introduced in the wrapper...