### PR TITLE
Support for file names on windows with spaces

### DIFF
--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -89,7 +89,7 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta, alg, m
     % Run the fast diffusion SNE implementation
     write_data(X, no_dims, theta, perplexity, max_iter);
     tic
-    [flag, cmdout] = system(['"' fullfile(tsne_path,'./bh_tsne') '"']);s
+    [flag, cmdout] = system(['"' fullfile(tsne_path,'./bh_tsne') '"']);
     if(flag~=0)
         error(cmdout);
     end

--- a/fast_tsne.m
+++ b/fast_tsne.m
@@ -89,7 +89,7 @@ function mappedX = fast_tsne(X, no_dims, initial_dims, perplexity, theta, alg, m
     % Run the fast diffusion SNE implementation
     write_data(X, no_dims, theta, perplexity, max_iter);
     tic
-    [flag, cmdout] = system(fullfile(tsne_path,'./bh_tsne'));
+    [flag, cmdout] = system(['"' fullfile(tsne_path,'./bh_tsne') '"']);s
     if(flag~=0)
         error(cmdout);
     end


### PR DESCRIPTION
Hi There,

I'm relatively new to Matlab development, so this may be wrong headed, but it worked for me. The path to my tsne folder contained files with spaces. This caused run time errors unless I wrapped the path in quotation marks.

Just thought I'd pass it up the chain in case it would help others.

Thanks,

Mark