### PR TITLE
make tsne.h C compatible

### DIFF
--- a/tsne.h
+++ b/tsne.h
@@ -34,30 +34,17 @@
 #ifndef TSNE_H
 #define TSNE_H
 
-
-static inline double sign(double x) { return (x == .0 ? .0 : (x < .0 ? -1.0 : 1.0)); }
-
-
-class TSNE
-{
-public:
+#ifdef __cplusplus
+extern "C" {
+namespace TSNE {
+#endif
     void run(double* X, int N, int D, double* Y, int no_dims, double perplexity, double theta, int rand_seed,
-             bool skip_random_init, int max_iter=1000, int stop_lying_iter=250, int mom_switch_iter=250);
+             bool skip_random_init, int max_iter, int stop_lying_iter, int mom_switch_iter);
     bool load_data(double** data, int* n, int* d, int* no_dims, double* theta, double* perplexity, int* rand_seed, int* max_iter);
     void save_data(double* data, int* landmarks, double* costs, int n, int d);
-    void symmetrizeMatrix(unsigned int** row_P, unsigned int** col_P, double** val_P, int N); // should be static!
-
-
-private:
-    void computeGradient(unsigned int* inp_row_P, unsigned int* inp_col_P, double* inp_val_P, double* Y, int N, int D, double* dC, double theta);
-    void computeExactGradient(double* P, double* Y, int N, int D, double* dC);
-    double evaluateError(double* P, double* Y, int N, int D);
-    double evaluateError(unsigned int* row_P, unsigned int* col_P, double* val_P, double* Y, int N, int D, double theta);
-    void zeroMean(double* X, int N, int D);
-    void computeGaussianPerplexity(double* X, int N, int D, double* P, double perplexity);
-    void computeGaussianPerplexity(double* X, int N, int D, unsigned int** _row_P, unsigned int** _col_P, double** _val_P, double perplexity, int K);
-    void computeSquaredEuclideanDistance(double* X, int N, int D, double* DD);
-    double randn();
+#ifdef __cplusplus
 };
+}
+#endif
 
 #endif

--- a/tsne_main.cpp
+++ b/tsne_main.cpp
@@ -13,10 +13,9 @@ int main() {
 	int origN, N, D, no_dims, max_iter;
 	double perplexity, theta, *data;
     int rand_seed = -1;
-    TSNE* tsne = new TSNE();
 
     // Read the parameters and the dataset
-	if(tsne->load_data(&data, &origN, &D, &no_dims, &theta, &perplexity, &rand_seed, &max_iter)) {
+	if(TSNE::load_data(&data, &origN, &D, &no_dims, &theta, &perplexity, &rand_seed, &max_iter)) {
 
 		// Make dummy landmarks
         N = origN;
@@ -28,10 +27,10 @@ int main() {
 		double* Y = (double*) malloc(N * no_dims * sizeof(double));
 		double* costs = (double*) calloc(N, sizeof(double));
         if(Y == NULL || costs == NULL) { printf("Memory allocation failed!\n"); exit(1); }
-		tsne->run(data, N, D, Y, no_dims, perplexity, theta, rand_seed, false, max_iter);
+		TSNE::run(data, N, D, Y, no_dims, perplexity, theta, rand_seed, false, max_iter, 250, 250);
 
 		// Save the results
-		tsne->save_data(Y, landmarks, costs, N, no_dims);
+		TSNE::save_data(Y, landmarks, costs, N, no_dims);
 
         // Clean up the memory
 		free(data); data = NULL;
@@ -39,5 +38,4 @@ int main() {
 		free(costs); costs = NULL;
 		free(landmarks); landmarks = NULL;
     }
-    delete(tsne);
 }


### PR DESCRIPTION
See issue #78

I also fixed two style issues, which made achieving C compatibility easier:

1. replace class with namespace
The TSNE class had no data. It was used as a namespace. So I made it a namespace.

2. make private methods static functions
Internal functions were private methods of the class. Since none of them are used in more than one file, the tool for the job is `static`, which makes a function only accessible to the cpp file (compilation unit) it is defined in.
To avoid bloating the diff by moving the functions around, I added declarations of the static functions on top of `tsne.cpp`. But if you move the function definitions around a bit (so they appear before they are used), the declarations can just be deleted.

The C++ compilation didn't change at all.
For C code it would look like this.
```
# compile C++
g++ -c tsne.cpp sptree.cpp
# compile C (tsne_main.c is not committed)
gcc -c tsne_main.c
# link
g++ tsne_main.o tsne.o sptree.o
```
If you want to distribute a static library:
```
ar rvs bhtsne.a tsne.o sptree.o
```
You have nearly 100% of C code here. It would be very little work to make this compile with both
`gcc *.c` and `g++ *.c`, which would allow people to link without a C++ compiler as well.