### PR TITLE
[bug] Fixing forking in python child thread

### DIFF
--- a/bhtsne.py
+++ b/bhtsne.py
@@ -202,7 +202,7 @@ def run_bh_tsne(data, no_dims=2, perplexity=50, theta=0.5, randseed=-1, verbose=
             data = load_data(data)
 
         init_bh_tsne(data, tmp_dir_path, no_dims=no_dims, perplexity=perplexity, theta=theta, randseed=randseed,verbose=verbose, initial_dims=initial_dims, use_pca=use_pca, max_iter=max_iter)
-        sys.exit(0)
+        os._exit(0)
     else:
         try:
             os.waitpid(child_pid, 0)


### PR DESCRIPTION
One issue with the python `bhtsne` wrapper is that when executing it multiple times from the same module rather than from the command line, the child thread from the fork doesn't actually die (via `sys.exit(0)`) and so future calls hang and quit. According to the [documentation](https://docs.python.org/3/library/os.html#os._exit), `os._exit(0)` should be used from the child process of a fork.