### PR TITLE
computeGaussianPerplexity: fix beta bug

### DIFF
--- a/tsne.cpp
+++ b/tsne.cpp
@@ -404,7 +404,7 @@ static void computeGaussianPerplexity(double* X, int N, int D, double* P, double
 				else {
 					max_beta = beta;
 					if(min_beta == -DBL_MAX || min_beta == DBL_MAX)
-						beta /= 2.0;
+						beta = fabs(beta) <= 1.0 ? -2.0 : beta / 2.0;
 					else
 						beta = (beta + min_beta) / 2.0;
 				}


### PR DESCRIPTION
When abs(beta) <= 1.0 and min_beta is DBL_MAX / -DBL_MAX, beta gets stuck between 1 and 0, even if the true value is far away. Offsetting beta to a value  v with abs(v) > 1.0 solves the problem. 