### PR TITLE
Update beta fix

### DIFF
--- a/tsne.cpp
+++ b/tsne.cpp
@@ -403,10 +403,15 @@ static void computeGaussianPerplexity(double* X, int N, int D, double* P, double
 				}
 				else {
 					max_beta = beta;
-					if(min_beta == -DBL_MAX || min_beta == DBL_MAX)
-						beta = fabs(beta) <= 1.0 ? -2.0 : beta / 2.0;
-					else
+					if(min_beta == -DBL_MAX || min_beta == DBL_MAX){
+						if (beta < 0) {
+              						beta *= 2;
+						} else {
+						      	beta = beta <= 1.0 ? -0.5 : beta / 2.0;
+						} 
+					} else {
 						beta = (beta + min_beta) / 2.0;
+					}
 				}
 			}
 


### PR DESCRIPTION
Previous fix didn't solve the problem, as for further iterations still would get stuck 0 - eps, for eps > 0. We need to *= 2 for values < 0 to find a first undershoot & get rid of INT_MIN / INT_MAX bounds (root of the problem).